### PR TITLE
use Long instead of formatted date string

### DIFF
--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/api/LogPersister.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/logger/api/LogPersister.java
@@ -732,11 +732,8 @@ public final class LogPersister {
      */
     private static JSONObject createJSONObject(final Logger.LEVEL level, final String pkg, final String message, long timestamp, final JSONObject jsonMetadata, final Throwable t) {
         JSONObject jsonObject = new JSONObject();
-        SimpleDateFormat s = new SimpleDateFormat("dd-MM-yyyy HH:mm:ss:S");
-        s.setTimeZone(TimeZone.getTimeZone("GMT"));
-        String format = s.format(timestamp);
         try {
-            jsonObject.put ("timestamp", format);
+            jsonObject.put ("timestamp", timestamp);
             jsonObject.put ("level", level.toString());
             jsonObject.put ("pkg", pkg);
             jsonObject.put ("msg", message);


### PR DESCRIPTION
Android is dumb when it handles formatted date strings.  The prior format we used had :S on the end for milliseconds, but on Android that's only one digit of precision.  On regular JVM it's three, so unit tests were always good and passing.  Running a real integration test revealed Android's dumbness.

According to SimpleDateFormat documentation, a single capital 'S' is three digits of precision:

[http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html](http://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html)

But Android has a "Note that 'S' represents fractional seconds" note in their docs:

[http://developer.android.com/reference/java/text/SimpleDateFormat.html](http://developer.android.com/reference/java/text/SimpleDateFormat.html)

Thanks a lot Android.
