### PR TITLE
Change metadata timestamp key to what Server expects

### DIFF
--- a/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/analytics/internal/MFPAnalyticsActivityLifecycleListener.java
+++ b/lib/src/main/java/com/ibm/mobilefirstplatform/clientsdk/android/analytics/internal/MFPAnalyticsActivityLifecycleListener.java
@@ -112,7 +112,7 @@ public class MFPAnalyticsActivityLifecycleListener {
             JSONObject metadata = new JSONObject();
             try {
                 metadata.put(BMSAnalytics.CATEGORY, APP_SESSION_CATEGORY);
-                metadata.put("timestamp", appUseStartTimestamp);
+                metadata.put(BMSAnalytics.TIMESTAMP_KEY, appUseStartTimestamp);
                 metadata.put(BMSAnalytics.APP_SESSION_ID_KEY, appSessionID);
             } catch (JSONException e) {
                 // should not happen


### PR DESCRIPTION
Analytics Server expects keys in the "metadata" JSON to be prefaced with a "$", else Server treats the key-value pair as CustomData.